### PR TITLE
Reference Vote-O-Mat in README

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -2,10 +2,19 @@
 
 [English Version](README.md)
 
-Mahlowat ist eine Implementierung eines Wahlpositionsvergleichswerkzeugs (voting advice application, VAA).
-
-Mahlowat ermöglicht es, die eigenen Positionen zu Thesen mit den Positionen von Gruppen oder Personen zu vergleichen,
+Mahlowat ist eine Implementierung eines Wahlpositionsvergleichswerkzeugs (voting advice application, VAA). Mahlowat ermöglicht es, die eigenen Positionen zu Thesen mit den Positionen von Gruppen oder Personen zu vergleichen,
 die zu einer Wahl kandidieren.
+
+Erweiterter Funktionsumfang
+---------------------------
+
+Wirf einen Blick auf [Vote-O-Mat](https://github.com/SilvanVerhoeven/vote-o-mat), falls du eine dieser Funktionen benötigst:
+
+- eingebaute Unterstützung für mehrere Sprachen
+- anonyme Nutzungsstatistiken
+- Anpassung von Mahlowat an eine bestimmte Marke (z.B. durch ein Logo)
+
+Vote-O-Mat ist eine Erweiterung von Mahlowat und funktioniert im Grundsatz gleich.
 
 
 Allgemeine Vorgehensweise

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 Mahlowat is an implementation of a voting advice application (VAA). It allows users to compare their opinion on selected theses
 to the opinions of groups or individuals competing in an election.
 
+Extended Features
+-----------------
+
+Take a look at [Vote-O-Mat](https://github.com/SilvanVerhoeven/vote-o-mat), if you need one of these features:
+
+- built-in support for multiple languages
+- anonymous usage statistics
+- branding of Mahlowat (e.g. via a Logo)
+
+Vote-O-Mat is an extension of Mahlowat and works equally in the fundamentals.
+
 
 General Approach
 ----------------


### PR DESCRIPTION
References Vote-O-Mat in Mahlowats READMEs, so people are aware of the extended version. Vote-O-Mat also references Mahlowat so people who do not need the extras can profit from the easier setup.
Proposed in #15 