### PR TITLE
Add short thesis description to voting process

### DIFF
--- a/js/mahlowat.js
+++ b/js/mahlowat.js
@@ -262,7 +262,7 @@ function loadThesis() {
 			$('#btn-toggle-thesis-more').fadeIn(200);
 		}
 	});
-	$('#thesis-number').text(t.thesis_number(currentThesis + 1));
+	$('#thesis-number').text(t.thesis_number(currentThesis + 1) + ": " + data.theses[thesis_id].s);
 	//			$('#thesis-text').text(data.theses[thesis_id].l);
 	$('#thesis-more').hide();
 	$('#thesis-more').text(data.theses[thesis_id].x);


### PR DESCRIPTION
The short descriptions are already there, but not used during voting process. It helps users to get into the thesis and they can recognize them later at the results more easily.